### PR TITLE
fix: 순간이동 이벤트 원격 호출 차단

### DIFF
--- a/Assets/_Shinjuku/Scripts/Teleport/CollisionTeleport.cs
+++ b/Assets/_Shinjuku/Scripts/Teleport/CollisionTeleport.cs
@@ -8,6 +8,7 @@ using VRC.Udon.Common.Enums;
 /// <summary>
 /// 로컬 사용자가 Trigger에 들어오면 화면 전환 연출 후 지정 위치로 이동
 /// </summary>
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 public class CollisionTeleport : UdonSharpBehaviour
 {
     [SerializeField] Transform TeleportTarget;
@@ -23,7 +24,7 @@ public class CollisionTeleport : UdonSharpBehaviour
             {
                 isTping = true;
                 DarkSlideAnimator.SetBool("IsTping", isTping);
-                SendCustomEventDelayedSeconds("TeleportPlayer", 0.58f, EventTiming.Update);
+                SendCustomEventDelayedSeconds(nameof(_TeleportPlayer), 0.58f, EventTiming.Update);
             }
         }
     }
@@ -31,8 +32,10 @@ public class CollisionTeleport : UdonSharpBehaviour
     /// <summary>
     /// 로컬 사용자의 목적지 이동 및 화면 전환 상태 종료
     /// </summary>
-    public void TeleportPlayer()
+    public void _TeleportPlayer()
     {
+        if (!isTping) return;
+
         Networking.LocalPlayer.TeleportTo(TeleportTarget.position, TeleportTarget.rotation);
         isTping = false;
         DarkSlideAnimator.SetBool("IsTping", isTping);


### PR DESCRIPTION
## 변경

- 순간이동 동작을 로컬 전용으로 고정
- 원격 호출 가능한 공개 이벤트 이름 제거
- 정상 트리거 상태일 때만 이동

Closes #10